### PR TITLE
[FE] SISC1-158 [FEAT] : 백테스팅 페이지 스켈레톤 구현

### DIFF
--- a/frontend/src/components/backtest/EntryRulesCard.jsx
+++ b/frontend/src/components/backtest/EntryRulesCard.jsx
@@ -1,0 +1,18 @@
+import styles from './EntryRulesCard.module.css';
+import SectionCard from './common/SectionCard';
+import RuleRow from './common/RuleRow';
+
+const EntryRulesCard = () => {
+  return (
+    <SectionCard
+      title="매수 조건"
+      description="행을 추가/삭제하여 규칙을 생성하세요."
+      actions={<button className={styles.button}>조건 추가 +</button>}
+    >
+      <RuleRow />
+      <RuleRow />
+    </SectionCard>
+  );
+};
+
+export default EntryRulesCard;

--- a/frontend/src/components/backtest/EntryRulesCard.module.css
+++ b/frontend/src/components/backtest/EntryRulesCard.module.css
@@ -1,0 +1,15 @@
+.button {
+  height: 40px;
+  padding: 0 24px;
+  border-radius: 10px;
+  border: 1px solid #0e1a2c;
+  background: #0e1a2c;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.button:hover {
+  opacity: 0.9;
+}

--- a/frontend/src/components/backtest/ExitRulesCard.jsx
+++ b/frontend/src/components/backtest/ExitRulesCard.jsx
@@ -1,0 +1,18 @@
+import styles from './ExitRulesCard.module.css';
+import SectionCard from './common/SectionCard';
+import RuleRow from './common/RuleRow';
+
+const ExitRulesCard = () => {
+  return (
+    <SectionCard
+      title="매도 조건"
+      description="행을 추가/삭제하여 규칙을 생성하세요."
+      actions={<button className={styles.button}>조건 추가 +</button>}
+    >
+      <RuleRow />
+      <RuleRow />
+    </SectionCard>
+  );
+};
+
+export default ExitRulesCard;

--- a/frontend/src/components/backtest/ExitRulesCard.module.css
+++ b/frontend/src/components/backtest/ExitRulesCard.module.css
@@ -1,0 +1,15 @@
+.button {
+  height: 40px;
+  padding: 0 24px;
+  border-radius: 10px;
+  border: 1px solid #0e1a2c;
+  background: #0e1a2c;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.button:hover {
+  opacity: 0.9;
+}

--- a/frontend/src/components/backtest/NotesCard.jsx
+++ b/frontend/src/components/backtest/NotesCard.jsx
@@ -1,0 +1,19 @@
+import styles from './NotesCard.module.css';
+import SectionCard from './common/SectionCard';
+
+const NotesCard = () => {
+  return (
+    <SectionCard
+      title="Note"
+      description="전략 의도, 리스크, 특기 포인트 등을 기록하세요."
+    >
+      <textarea
+        className={styles.textarea}
+        placeholder="예) RSI 14 기준 모멘텀 반전 + SMA 장기 추세 필터…"
+        rows={5}
+      />
+    </SectionCard>
+  );
+};
+
+export default NotesCard;

--- a/frontend/src/components/backtest/NotesCard.module.css
+++ b/frontend/src/components/backtest/NotesCard.module.css
@@ -1,0 +1,19 @@
+.textarea {
+  width: 100%;
+  height: auto;
+  padding: 12px;
+  border: 0.4px solid #e5e7eb;
+  border-color: #afafaf;
+  border-radius: 10px;
+  background: #fff;
+  font-size: 16px;
+  outline: none;
+  box-sizing: border-box;
+  max-width: 100%;
+  resize: vertical;
+}
+
+.textarea:focus {
+  border-color: #c7d2fe;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}

--- a/frontend/src/components/backtest/StocksCard.jsx
+++ b/frontend/src/components/backtest/StocksCard.jsx
@@ -1,0 +1,20 @@
+import styles from './StocksCard.module.css';
+import SectionCard from './common/SectionCard';
+
+const StocksCard = () => {
+  return (
+    <SectionCard title="주식" additionalInfo="*복수 선택 가능" actions={null}>
+      <div className={styles.stockRow}>
+        <input className={styles.input} placeholder="주식을 입력해주세요." />
+        <button className={styles.button}>Add</button>
+      </div>
+
+      <div className={styles.chips}>
+        <span className={styles.chip}>AAPL ✕</span>
+        <span className={styles.chip}>MSFT ✕</span>
+      </div>
+    </SectionCard>
+  );
+};
+
+export default StocksCard;

--- a/frontend/src/components/backtest/StocksCard.module.css
+++ b/frontend/src/components/backtest/StocksCard.module.css
@@ -1,0 +1,56 @@
+.stockRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  padding: 6px 10px;
+  font-size: 13px;
+  color: #111827;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+}
+
+.input {
+  width: 100%;
+  height: 40px;
+  padding: 0 16px;
+  border: 0.4px solid #e5e7eb;
+  border-color: #afafaf;
+  border-radius: 10px;
+  background: #fff;
+  font-size: 16px;
+  outline: none;
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+.input:focus {
+  border-color: #c7d2fe;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.button {
+  height: 40px;
+  padding: 0 24px;
+  border-radius: 10px;
+  border: 1px solid #0e1a2c;
+  background: #0e1a2c;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.button:hover {
+  opacity: 0.9;
+}

--- a/frontend/src/components/backtest/StrategyInfoCard.jsx
+++ b/frontend/src/components/backtest/StrategyInfoCard.jsx
@@ -1,0 +1,62 @@
+import styles from './StrategyInfoCard.module.css';
+import SectionCard from './common/SectionCard';
+
+const StrategyInfoCard = () => {
+  return (
+    <SectionCard title="전략 기본정보">
+      <div>
+        <div className={styles.fieldGroup}>
+          <div className={styles.field}>
+            <label className={styles.label}>전략 이름</label>
+            <input
+              className={styles.input}
+              placeholder="변호를 입력해주세요."
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label}>시작일</label>
+            <input className={styles.input} placeholder="YYYY / MM / DD" />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label}>종료일</label>
+            <input className={styles.input} placeholder="YYYY / MM / DD" />
+          </div>
+        </div>
+
+        <div className={styles.fieldGroup}>
+          <div className={styles.field}>
+            <label className={styles.label}>타임 프레임</label>
+            <select className={styles.select}>
+              <option>D</option>
+              <option>W</option>
+              <option>M</option>
+            </select>
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label}>
+              초기 자본<span className={styles.span}>($)</span>
+            </label>
+            <input
+              className={styles.input}
+              type="text"
+              placeholder="100000"
+              inputMode="numeric"
+            />
+          </div>
+
+          <div className={`${styles.field} ${styles.fieldButton}`}>
+            <label className={styles.label} aria-hidden="true">
+              &nbsp;
+            </label>
+            <button className={styles.button}>전략 폴더에 넣기</button>
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  );
+};
+
+export default StrategyInfoCard;

--- a/frontend/src/components/backtest/StrategyInfoCard.module.css
+++ b/frontend/src/components/backtest/StrategyInfoCard.module.css
@@ -1,0 +1,63 @@
+.fieldGroup {
+  display: grid;
+  margin-top: 16px;
+  gap: 50px;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+}
+
+.label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #616161;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.input,
+.select {
+  width: 100%;
+  height: 40px;
+  padding: 0 16px;
+  border: 0.4px solid #e5e7eb;
+  border-color: #afafaf;
+  border-radius: 10px;
+  background: #fff;
+  font-size: 16px;
+  box-sizing: border-box;
+  outline: none;
+  max-width: 100%;
+}
+
+.input:focus,
+.select:focus {
+  border-color: #c7d2fe;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.button {
+  height: 40px;
+  padding: 0 24px;
+  border-radius: 10px;
+  border: 1px solid #0e1a2c;
+  background: #0e1a2c;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.button:hover {
+  opacity: 0.9;
+}
+
+.span {
+  font-size: 16px;
+  font-weight: 500;
+  color: #339fff;
+}

--- a/frontend/src/components/backtest/common/RuleRow.jsx
+++ b/frontend/src/components/backtest/common/RuleRow.jsx
@@ -1,0 +1,40 @@
+import styles from './RuleRow.module.css';
+
+const RuleRow = () => {
+  return (
+    <div className={styles.ruleRow}>
+      <select className={styles.select}>
+        <option>SMA</option>
+        <option>EMA</option>
+        <option>RSI</option>
+        <option>MACD</option>
+      </select>
+
+      <select className={styles.select}>
+        <option>Crosses Above</option>
+        <option>Crosses Below</option>
+        <option>Greater Than</option>
+        <option>Less Than</option>
+      </select>
+
+      <input className={styles.input} defaultValue="50" />
+
+      <select className={styles.select}>
+        <option>SMA 200</option>
+        <option>EMA 200</option>
+        <option>Price</option>
+      </select>
+
+      <select className={styles.select}>
+        <option>D</option>
+        <option>W</option>
+        <option>M</option>
+      </select>
+      <button className={styles.btnIcon} aria-label="more options">
+        🗑️
+      </button>
+    </div>
+  );
+};
+
+export default RuleRow;

--- a/frontend/src/components/backtest/common/RuleRow.module.css
+++ b/frontend/src/components/backtest/common/RuleRow.module.css
@@ -1,0 +1,47 @@
+.input,
+.select {
+  width: 100%;
+  height: 40px;
+  padding: 0 16px;
+  border: 0.4px solid #e5e7eb;
+  border-color: #afafaf;
+  border-radius: 10px;
+  background: #fff;
+  font-size: 16px;
+  outline: none;
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+.input:focus,
+.select:focus {
+  border-color: #c7d2fe;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.btnIcon {
+  height: 40px;
+  padding: 0 10px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.ruleRow {
+  display: grid;
+  grid-template-columns:
+    minmax(90px, 140px) minmax(120px, 200px) 80px minmax(120px, 200px)
+    80px 40px;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+@media (max-width: 860px) {
+  .ruleRow {
+    grid-template-columns: 1fr 1fr;
+  }
+  .ruleRow > :nth-child(n) {
+    min-width: 0;
+  }
+}

--- a/frontend/src/components/backtest/common/SectionCard.jsx
+++ b/frontend/src/components/backtest/common/SectionCard.jsx
@@ -1,0 +1,61 @@
+import { useId, useState } from 'react';
+import styles from './SectionCard.module.css';
+
+const SectionCard = ({
+  title,
+  additionalInfo,
+  description,
+  actions,
+  collapsible = false,
+  defaultCollapsed = false,
+  children,
+  className = '',
+  footer,
+}) => {
+  const titleId = useId();
+  const [open, setOpen] = useState(!defaultCollapsed);
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className={`${styles.section} ${className || ''}`}
+    >
+      <div className={styles.header}>
+        <div>
+          <h2 id={titleId} className={styles.title}>
+            {title}
+            {additionalInfo ? (
+              <span className={styles.additionalInfo}>{additionalInfo}</span>
+            ) : null}
+          </h2>
+          {description ? <p className={styles.desc}>{description}</p> : null}
+        </div>
+
+        <div className={styles.actions}>
+          {actions}
+          {collapsible && (
+            <button
+              type="button"
+              className={styles.collapseBtn}
+              aria-expanded={open}
+              aria-controls={`${titleId}-panel`}
+              onClick={() => setOpen((v) => !v)}
+            >
+              {open ? '접기' : '펼치기'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {open && (
+        <div id={`${titleId}-panel`} className={styles.body}>
+          {children}
+        </div>
+      )}
+
+      {footer ? <div className={styles.footer}>{footer}</div> : null}
+    </section>
+  );
+};
+
+export default SectionCard;

--- a/frontend/src/components/backtest/common/SectionCard.module.css
+++ b/frontend/src/components/backtest/common/SectionCard.module.css
@@ -1,0 +1,58 @@
+.section {
+  background-color: #f9f9f9;
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: #171717;
+}
+
+.additionalInfo {
+  padding-left: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  color: #339fff;
+}
+
+.desc {
+  margin-top: 4px;
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.collapseBtn {
+  padding: 6px 10px;
+  font-size: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.body {
+  display: block;
+}
+
+.footer {
+  margin-top: 12px;
+  font-size: 12px;
+  color: #6b7280;
+}

--- a/frontend/src/pages/BackTest.jsx
+++ b/frontend/src/pages/BackTest.jsx
@@ -1,5 +1,12 @@
+import styles from './BackTest.module.css';
+
 const BackTest = () => {
   return <div>BackTest Page</div>;
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.pageTitle}>백테스팅</h1>
+    </div>
+  );
 };
 
 export default BackTest;

--- a/frontend/src/pages/BackTest.jsx
+++ b/frontend/src/pages/BackTest.jsx
@@ -2,6 +2,7 @@ import styles from './BackTest.module.css';
 import StrategyInfoCard from '../components/backtest/StrategyInfoCard';
 import StocksCard from '../components/backtest/StocksCard';
 import EntryRulesCard from '../components/backtest/EntryRulesCard';
+import ExitRulesCard from '../components/backtest/ExitRulesCard';
 
 const BackTest = () => {
   return (
@@ -11,6 +12,7 @@ const BackTest = () => {
       <StrategyInfoCard />
       <StocksCard />
       <EntryRulesCard />
+      <ExitRulesCard />
     </div>
   );
 };

--- a/frontend/src/pages/BackTest.jsx
+++ b/frontend/src/pages/BackTest.jsx
@@ -1,10 +1,13 @@
 import styles from './BackTest.module.css';
+import StrategyInfoCard from '../components/backtest/StrategyInfoCard';
 
 const BackTest = () => {
   return <div>BackTest Page</div>;
   return (
     <div className={styles.container}>
       <h1 className={styles.pageTitle}>백테스팅</h1>
+
+      <StrategyInfoCard />
     </div>
   );
 };

--- a/frontend/src/pages/BackTest.jsx
+++ b/frontend/src/pages/BackTest.jsx
@@ -1,13 +1,14 @@
 import styles from './BackTest.module.css';
 import StrategyInfoCard from '../components/backtest/StrategyInfoCard';
+import StocksCard from '../components/backtest/StocksCard';
 
 const BackTest = () => {
-  return <div>BackTest Page</div>;
   return (
     <div className={styles.container}>
       <h1 className={styles.pageTitle}>백테스팅</h1>
 
       <StrategyInfoCard />
+      <StocksCard />
     </div>
   );
 };

--- a/frontend/src/pages/BackTest.jsx
+++ b/frontend/src/pages/BackTest.jsx
@@ -3,6 +3,7 @@ import StrategyInfoCard from '../components/backtest/StrategyInfoCard';
 import StocksCard from '../components/backtest/StocksCard';
 import EntryRulesCard from '../components/backtest/EntryRulesCard';
 import ExitRulesCard from '../components/backtest/ExitRulesCard';
+import NotesCard from '../components/backtest/NotesCard';
 
 const BackTest = () => {
   return (
@@ -13,6 +14,7 @@ const BackTest = () => {
       <StocksCard />
       <EntryRulesCard />
       <ExitRulesCard />
+      <NotesCard />
     </div>
   );
 };

--- a/frontend/src/pages/BackTest.jsx
+++ b/frontend/src/pages/BackTest.jsx
@@ -1,6 +1,7 @@
 import styles from './BackTest.module.css';
 import StrategyInfoCard from '../components/backtest/StrategyInfoCard';
 import StocksCard from '../components/backtest/StocksCard';
+import EntryRulesCard from '../components/backtest/EntryRulesCard';
 
 const BackTest = () => {
   return (
@@ -9,6 +10,7 @@ const BackTest = () => {
 
       <StrategyInfoCard />
       <StocksCard />
+      <EntryRulesCard />
     </div>
   );
 };

--- a/frontend/src/pages/BackTest.module.css
+++ b/frontend/src/pages/BackTest.module.css
@@ -1,0 +1,14 @@
+.container {
+  margin: 0 auto;
+  padding: 80px;
+  display: grid;
+  gap: 30px;
+  background: #ffffff;
+}
+
+.pageTitle {
+  margin-bottom: 40px;
+  font-size: 28px;
+  font-weight: 600;
+  color: #171717;
+}


### PR DESCRIPTION
## 1) 작업한 이슈번호

🔗: [SISC1-158 백테스팅 페이지 스켈레톤 구현](https://sic1.atlassian.net/browse/SISC1-5?atlOrigin=eyJpIjoiNmRhOTRlYmU0M2VmNDg3ODgwZDU5OTYwYThmZTZmMWYiLCJwIjoiaiJ9)

## 2) 변경 요약 (What & Why)

### 무엇을 What?
- Figma 디자인을 기반으로 백테스텡 페이지에서 필요한 요소들을 뼈대만 구현하였습니다.
- 아직 상세 기능에 대해서는 적용시키지 않았기에 추후에 수정할 사항들이 많습니다.

### 왜 Why?
- 기본적인 뼈대 구성이 필요했고, 아직 기능과 동작에 대해 자세히 아는 정보가 없어 디자인에 맞춰서 레이아웃 및 필수 요소만 구현해놨습니다.

## 3) 스크린샷/동영상 (UI 변경 시)

<img width="1919" height="956" alt="image" src="https://github.com/user-attachments/assets/a226413c-a277-4d99-9ec7-712cde9e5e7c" />
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/1eb6f39d-3644-4344-a01a-ed536142c113" />

- `main` 브랜치 변경 이전에 만들어진 브랜치여서 아직 `main` 태그에 padding 값이 남아있습니다.

## 4) 상세 변경사항 (전부 다)

- 라우팅/페이지: 백테스팅 페이지로 이동하면 /back-test 로 이동
- 컴포넌트: pages 폴더에 BackTest 컴포넌트가 있고, 해당 컴포넌트 내부에서 <StrategyInfoCard />, <StocksCard />, <EntryRulesCard />, <ExitRulesCard />, <NotesCard /> 5가지 Card 컴포넌트를 import 해서 사용합니다.
- 상태관리: 미구현 (추후에 필요한 상태들에 대해서 설명하겠습니다)
- API 호출: X
- 스타일: Figma 디자인에 최대한 맞춰서 작성했습니다.
- 기타:

## 5) 참고사항

정말 뼈대만 만들어놓은 것이라 추후 수정할 부분이 굉장히 많습니다. (버튼 및 Select 요소 모두 임시 값) 리뷰하시는데 참고해주시면 감사하겠습니다.