### PR TITLE
[FE] SISC1-94 [FEAT] 회원가입 페이지 및 이메일 인증 팝업 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import BackTest from './pages/BackTest';
 import Mypage from './pages/Mypage';
 import AttendanceManage from './pages/AttendanceManage';
 import Login from './pages/Login';
+import SignUp from './pages/SignUp';
 import QuantBot from './pages/QuantBot';
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
     <>
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<SignUp />} />
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/attendance" element={<Attendance />} />

--- a/frontend/src/components/login/LoginForm.jsx
+++ b/frontend/src/components/login/LoginForm.jsx
@@ -8,6 +8,7 @@ import SocialLoginButtons from './SocialLoginButtons';
 const LoginForm = () => {
   const [id, setId] = useState('');
   const [password, setPassword] = useState('');
+
   const nav = useNavigate();
 
   const isFormValid = id.trim() !== '' && password.trim() !== '';
@@ -27,56 +28,58 @@ const LoginForm = () => {
   };
 
   return (
-    <div className={styles.formContainer}>
-      <form className={styles.loginForm} onSubmit={handleLogin}>
-        <div className={styles.logoBox}>
-          <img src={sejong_logo} alt="sejong_logo" className={styles.logo} />
-        </div>
+    <>
+      <div className={styles.formContainer}>
+        <form className={styles.loginForm} onSubmit={handleLogin}>
+          <div className={styles.logoBox}>
+            <img src={sejong_logo} alt="sejong_logo" className={styles.logo} />
+          </div>
 
-        <h1>Sejong Investment Scholars Club</h1>
-        <div className={styles.inputGroup}>
-          <label htmlFor="email">Email</label>
-          <input
-            type="email"
-            id="email"
-            value={id}
-            onChange={(e) => setId(e.target.value)}
-            placeholder="이메일을 입력하세요"
-          />
-        </div>
-        <div className={styles.inputGroup}>
-          <label htmlFor="password">비밀번호</label>
-          <input
-            type="password"
-            id="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="비밀번호를 입력하세요"
-          />
-        </div>
-        <button
-          type="submit"
-          className={styles.loginButton}
-          disabled={!isFormValid}
-        >
-          로그인
-        </button>
-      </form>
-      <nav className={styles.findContainer}>
-        <NavLink to="/find-id" className={styles.text}>
-          아이디 찾기
-        </NavLink>
-        <span className={styles.divider} aria-hidden="true">
-          |
-        </span>
-        <NavLink to="/find-password" className={styles.text}>
-          비밀번호 찾기
-        </NavLink>
-      </nav>
+          <h1>Sejong Investment Scholars Club</h1>
+          <div className={styles.inputGroup}>
+            <label htmlFor="email">Email</label>
+            <input
+              type="email"
+              id="email"
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              placeholder="이메일을 입력하세요"
+            />
+          </div>
+          <div className={styles.inputGroup}>
+            <label htmlFor="password">비밀번호</label>
+            <input
+              type="password"
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="비밀번호를 입력하세요"
+            />
+          </div>
+          <button
+            type="submit"
+            className={styles.loginButton}
+            disabled={!isFormValid}
+          >
+            로그인
+          </button>
+        </form>
+        <nav className={styles.findContainer}>
+          <NavLink to="/find-id" className={styles.text}>
+            아이디 찾기
+          </NavLink>
+          <span className={styles.divider} aria-hidden="true">
+            |
+          </span>
+          <NavLink to="/find-password" className={styles.text}>
+            비밀번호 찾기
+          </NavLink>
+        </nav>
 
-      {/* 소셜 로그인 버튼들 */}
-      <SocialLoginButtons />
-    </div>
+        {/* 소셜 로그인 버튼들 */}
+        <SocialLoginButtons />
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/components/login/LoginForm.module.css
+++ b/frontend/src/components/login/LoginForm.module.css
@@ -78,12 +78,12 @@
 .findContainer {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   font-size: 14px;
   color: #9ca3af;
   align-self: flex-start;
   padding-left: 12px;
-  padding-top: 20px;
+  padding-top: 10px;
 }
 .text {
   color: inherit;

--- a/frontend/src/components/signup/EmailVerificationPopup.jsx
+++ b/frontend/src/components/signup/EmailVerificationPopup.jsx
@@ -8,7 +8,10 @@ const EmailVerificationPopup = ({ onClose, onEmailVerified }) => {
   const handleSendCode = () => {
     if (!isCodeSent) {
       alert('인증번호가 전송되었습니다.');
-      setIsCodeSent(true);
+
+      // 3초정도 대기하는 로직 추가 필요
+
+      setIsCodeSent(true); // 3초 이후 재전송 버튼 활성화
     } else {
       alert('인증번호가 재전송되었습니다.');
     }

--- a/frontend/src/components/signup/EmailVerificationPopup.jsx
+++ b/frontend/src/components/signup/EmailVerificationPopup.jsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import styles from './EmailVerificationPopup.module.css';
+
+const EmailVerificationPopup = ({ onClose, onEmailVerified }) => {
+  const [code, setCode] = useState('');
+  const [isCodeSent, setIsCodeSent] = useState(false);
+
+  const handleSendCode = () => {
+    if (!isCodeSent) {
+      alert('인증번호가 전송되었습니다.');
+      setIsCodeSent(true);
+    } else {
+      alert('인증번호가 재전송되었습니다.');
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    alert(`입력된 인증번호: ${code}`);
+
+    // 이메일 인증 성공 시 수행
+    onEmailVerified(); // 부모의 setConfirmEmail() 호출
+    onClose(); // 팝업 닫기
+  };
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.popup}>
+        <h1>이메일 인증</h1>
+        <form onSubmit={handleSubmit}>
+          <div className={styles.inputGroup}>
+            <label htmlFor="verification-code" className={styles.label}>
+              인증번호
+            </label>
+            <div className={styles.verificationContainer}>
+              <input
+                type="text"
+                id="verification-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="인증번호를 입력하세요"
+                className={styles.codeInput}
+              />
+              <button
+                type="button"
+                className={`${styles.button} ${styles.sendButton}`}
+                onClick={handleSendCode}
+              >
+                {isCodeSent ? '재전송' : '인증번호 보내기'}
+              </button>
+            </div>
+          </div>
+          <div className={styles.buttonGroup}>
+            <button
+              type="submit"
+              className={`${styles.button} ${styles.submitButton}`}
+            >
+              제출
+            </button>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.closeButton}`}
+              onClick={onClose}
+            >
+              닫기
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EmailVerificationPopup;

--- a/frontend/src/components/signup/EmailVerificationPopup.module.css
+++ b/frontend/src/components/signup/EmailVerificationPopup.module.css
@@ -1,0 +1,84 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.popup {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 8px;
+  width: 400px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.popup h1 {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  text-align: center;
+  font-size: 20px;
+}
+
+.inputGroup {
+  margin-bottom: 1rem;
+}
+
+.label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.verificationContainer {
+  justify-content: space-between;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.codeInput {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.buttonGroup {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1.5rem;
+}
+
+.button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.submitButton {
+  background-color: #007bff;
+  color: white;
+}
+
+.resendButton {
+  background-color: #6c757d;
+  color: white;
+}
+
+.sendButton {
+  background-color: #6c757d;
+  color: white;
+  min-width: 100px;
+  text-align: center;
+}
+
+.closeButton {
+  background-color: #dc3545;
+  color: white;
+}

--- a/frontend/src/components/signup/SignUpForm.jsx
+++ b/frontend/src/components/signup/SignUpForm.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import loginStyles from '../login/LoginForm.module.css';
+import styles from '../login/LoginForm.module.css'; // 로그인 페이지와 유사하므로 LoginForm.module.css를 사용
 import signupStyles from './SignUpForm.module.css';
 import sejong_logo from '../../assets/sejong_logo.png';
 import EmailVerificationPopup from './EmailVerificationPopup';
@@ -8,6 +8,7 @@ import EmailVerificationPopup from './EmailVerificationPopup';
 const SignUpForm = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [isPopupOpen, setPopupOpen] = useState(false);
   const [confirmEmail, setConfirmEmail] = useState(false);
@@ -19,9 +20,16 @@ const SignUpForm = () => {
     return emailRegex.test(email);
   };
 
+  // 핸드폰 번호 유효성 검사
+  const isPhoneNumberValid = () => {
+    const phoneRegex = /^\d{10,11}$/;
+    return phoneRegex.test(phoneNumber);
+  };
+
   // 회원가입 제출 유효성 검사
   const isFormValid =
-    email.trim() !== '' &&
+    isEmailValid() &&
+    isPhoneNumberValid() &&
     password.trim() !== '' &&
     password === confirmPassword &&
     confirmEmail;
@@ -49,18 +57,13 @@ const SignUpForm = () => {
 
   return (
     <>
-      <div className={loginStyles.formContainer}>
-        <form className={loginStyles.loginForm} onSubmit={handleSignUp}>
-          <div className={loginStyles.logoBox}>
-            <img
-              src={sejong_logo}
-              alt="sejong_logo"
-              className={loginStyles.logo}
-            />
+      <div className={styles.formContainer}>
+        <form className={styles.loginForm} onSubmit={handleSignUp}>
+          <div className={styles.logoBox}>
+            <img src={sejong_logo} alt="sejong_logo" className={styles.logo} />
           </div>
-
           <h1>Sejong Investment Scholars Club</h1>
-          <div className={loginStyles.inputGroup}>
+          <div className={styles.inputGroup}>
             <label htmlFor="email">Email</label>
             <div className={signupStyles.emailContainer}>
               <input
@@ -81,7 +84,17 @@ const SignUpForm = () => {
               </button>
             </div>
           </div>
-          <div className={loginStyles.inputGroup}>
+          <div className={styles.inputGroup}>
+            <label htmlFor="phone">핸드폰 번호</label>
+            <input
+              type="text"
+              id="phone"
+              value={phoneNumber}
+              onChange={(e) => setPhoneNumber(e.target.value)}
+              placeholder="ex) 01012345678"
+            />
+          </div>
+          <div className={styles.inputGroup}>
             <label htmlFor="password">비밀번호</label>
             <input
               type="password"
@@ -91,7 +104,7 @@ const SignUpForm = () => {
               placeholder="비밀번호를 입력하세요"
             />
           </div>
-          <div className={loginStyles.inputGroup}>
+          <div className={styles.inputGroup}>
             <label htmlFor="confirm-password">비밀번호 확인</label>
             <input
               type="password"
@@ -103,7 +116,7 @@ const SignUpForm = () => {
           </div>
           <button
             type="submit"
-            className={loginStyles.loginButton}
+            className={styles.loginButton}
             disabled={!isFormValid}
           >
             회원가입

--- a/frontend/src/components/signup/SignUpForm.jsx
+++ b/frontend/src/components/signup/SignUpForm.jsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import loginStyles from '../login/LoginForm.module.css';
+import signupStyles from './SignUpForm.module.css';
+import sejong_logo from '../../assets/sejong_logo.png';
+import EmailVerificationPopup from './EmailVerificationPopup';
+
+const SignUpForm = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isPopupOpen, setPopupOpen] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState(false);
+  const nav = useNavigate();
+
+  // 이메일 입력 형태가 맞는지 검사
+  const isEmailValid = () => {
+    const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+    return emailRegex.test(email);
+  };
+
+  // 회원가입 제출 유효성 검사
+  const isFormValid =
+    email.trim() !== '' &&
+    password.trim() !== '' &&
+    password === confirmPassword &&
+    confirmEmail;
+
+  const handleSignUp = (e) => {
+    e.preventDefault();
+
+    // api 자리
+
+    // localStorage.setItem('authToken', 'dummy-token-12345');
+    nav('/login'); // 회원가입 성공 시 로그인 페이지 이동
+  };
+
+  // 이메일 인증 팝업
+  const openPopup = () => {
+    setPopupOpen(true);
+  };
+  const closePopup = () => {
+    setPopupOpen(false);
+  };
+
+  const handleEmailVerified = () => {
+    setConfirmEmail(true);
+  };
+
+  return (
+    <>
+      <div className={loginStyles.formContainer}>
+        <form className={loginStyles.loginForm} onSubmit={handleSignUp}>
+          <div className={loginStyles.logoBox}>
+            <img
+              src={sejong_logo}
+              alt="sejong_logo"
+              className={loginStyles.logo}
+            />
+          </div>
+
+          <h1>Sejong Investment Scholars Club</h1>
+          <div className={loginStyles.inputGroup}>
+            <label htmlFor="email">Email</label>
+            <div className={signupStyles.emailContainer}>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="이메일을 입력하세요"
+                className={signupStyles.emailInput}
+              />
+              <button
+                type="button"
+                onClick={openPopup}
+                className={signupStyles.verifyButton}
+                disabled={!isEmailValid()}
+              >
+                인증
+              </button>
+            </div>
+          </div>
+          <div className={loginStyles.inputGroup}>
+            <label htmlFor="password">비밀번호</label>
+            <input
+              type="password"
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="비밀번호를 입력하세요"
+            />
+          </div>
+          <div className={loginStyles.inputGroup}>
+            <label htmlFor="confirm-password">비밀번호 확인</label>
+            <input
+              type="password"
+              id="confirm-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="비밀번호를 한번 더 입력하세요"
+            />
+          </div>
+          <button
+            type="submit"
+            className={loginStyles.loginButton}
+            disabled={!isFormValid}
+          >
+            회원가입
+          </button>
+        </form>
+      </div>
+      {isPopupOpen && (
+        <EmailVerificationPopup
+          onClose={closePopup}
+          onEmailVerified={handleEmailVerified}
+        />
+      )}
+    </>
+  );
+};
+
+export default SignUpForm;

--- a/frontend/src/components/signup/SignUpForm.module.css
+++ b/frontend/src/components/signup/SignUpForm.module.css
@@ -1,0 +1,24 @@
+.emailContainer {
+  display: flex;
+  align-items: center;
+}
+
+.emailInput {
+  flex-grow: 1;
+  margin-right: 10px;
+}
+
+.verifyButton {
+  padding: 12px 15px;
+  width: 60px;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+.verifyButton:disabled {
+  background-color: #d5d5d5;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/Login.module.css
+++ b/frontend/src/pages/Login.module.css
@@ -1,4 +1,5 @@
-.loginContainer {
+.loginContainer,
+.signUpContainer {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -3,7 +3,7 @@ import styles from './Login.module.css';
 
 const SignUp = () => {
   return (
-    <div className={styles.loginContainer}>
+    <div className={styles.signUpContainer}>
       <SignUpForm />
     </div>
   );

--- a/frontend/src/pages/SignUp.jsx
+++ b/frontend/src/pages/SignUp.jsx
@@ -1,0 +1,12 @@
+import SignUpForm from '../components/signup/SignUpForm';
+import styles from './Login.module.css';
+
+const SignUp = () => {
+  return (
+    <div className={styles.loginContainer}>
+      <SignUpForm />
+    </div>
+  );
+};
+
+export default SignUp;


### PR DESCRIPTION
## 1) 작업한 이슈번호
SISC1-94
https://sic1.atlassian.net/jira/software/projects/SISC1/boards/1/backlog?epics=visible&issueParent=10001%2C10002%2C10003&jql=parent%20%3D%20SISC1-3&selectedIssue=SISC1-94

## 2) 변경 요약 (What & Why)

- **무엇을** 변경했는지: 
  - 회원가입 기능을 위한 회원가입 페이지 구현
  - 사용자의 이메일, 전화번호, 비밀번호, 비밀번호 한번 더 입력받음
  - 이메일은 인증 버튼을 눌러 팝업을 띄우고, 코드를 입력하여 인증할 수 있음
  - 인증 & 입력의 유효성 검사를 통해 통과했을 시에만 회원가입 버튼이 활성화됨
- **왜** 변경했는지(문제/목표): 

## 3) 스크린샷/동영상 (UI 변경 시)

> 전/후 비교, 반응형(모바일/데스크톱) 캡쳐

- Before:
- After:
<img width="870" height="848" alt="image" src="https://github.com/user-attachments/assets/8a705930-b4cc-4bd1-99e2-f5d448766d2f" />
<img width="866" height="842" alt="image" src="https://github.com/user-attachments/assets/257d0d27-dc93-4e8a-a6a6-82d34beba5a7" />

## 4) 상세 변경사항 (전부 다)

- 라우팅/페이지: App.jsx(라우팅 설정 추가), SignUp.jsx(큰 틀)
- 컴포넌트:  SignUpForm.jsx(회원가입 폼), EmailVerificationPopup.jsx(이메일 인증 팝업)
- 상태관리:
- API 호출: 
- 스타일: Sign.module.css(로그인 & 회원가입 페이지 동일 디자인), LoginForm.module.css(회원가입 페이지가 로그인 페이지와 비슷하므로 추가 디자인만 넣고 재활용), EmailVerificationPopup.module.css(이메일 인증 팝업 디자인)
- 기타:

## 5) 참고사항
이메일 인증 api 연동 필요
메일 전송 후 3초 대기하는 로직 필요
