### PR TITLE
feat: 베팅 이력 리턴 값 추가

### DIFF
--- a/backend/src/main/java/org/sejongisc/backend/betting/dto/UserBetResponse.java
+++ b/backend/src/main/java/org/sejongisc/backend/betting/dto/UserBetResponse.java
@@ -3,9 +3,11 @@ package org.sejongisc.backend.betting.dto;
 import lombok.Builder;
 import lombok.Getter;
 import org.sejongisc.backend.betting.entity.BetOption;
+import org.sejongisc.backend.betting.entity.BetRound;
 import org.sejongisc.backend.betting.entity.BetStatus;
 import org.sejongisc.backend.betting.entity.UserBet;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -22,8 +24,17 @@ public class UserBetResponse {
     private Boolean isCorrect;  // 결과 (성공 여부)
     private Integer earnedPoints;
 
+    // [추가] 인원수 정보를 상세하게 분리
+    private BigDecimal previousClosePrice; // 종가 (베팅 기준)
+    private BigDecimal settleClosePrice;   // 다음 날 종가 (정산 결과)
+
+    private int upBetCount;    // 상승 베팅 인원
+    private int downBetCount;  // 하락 베팅 인원
+
     // Entity -> DTO 변환 메서드
     public static UserBetResponse from(UserBet bet) {
+        BetRound round = bet.getRound();
+
         return UserBetResponse.builder()
                 .userBetId(bet.getUserBetId())
                 // 여기서 bet.getRound()를 호출할 때 영속성 컨텍스트가 살아있어야 함 (Service 내부)
@@ -36,6 +47,10 @@ public class UserBetResponse {
                 .betStatus(bet.getBetStatus())
                 .isCorrect(bet.isCorrect())        // boolean 타입의 Getter는 isCorrect()
                 .earnedPoints(bet.getPayoutPoints()) // 엔티티 필드명이 payoutPoints임
+                .previousClosePrice(round.getPreviousClosePrice())
+                .settleClosePrice(round.getSettleClosePrice())
+                .upBetCount(round.getUpBetCount())     // 상승 인원
+                .downBetCount(round.getDownBetCount()) // 하락 인원
                 .build();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 베팅 응답에 추가 정보 제공: 이전 종가, 결제 종가, 상승 베팅 수, 하락 베팅 수가 이제 포함됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->