### PR TITLE
BE-FEAT-게시판-하위-목록-및-삭제-기능-추가

### DIFF
--- a/backend/src/main/java/org/sejongisc/backend/board/controller/BoardController.java
+++ b/backend/src/main/java/org/sejongisc/backend/board/controller/BoardController.java
@@ -160,6 +160,34 @@ public class BoardController {
     return ResponseEntity.ok(postService.getParentBoards());
   }
 
+
+  // 게시판 생성
+  @Operation(
+          summary = "하위 게시판 목록 조회",
+          description = "하위 게시판 목록을 조회합니다."
+  )
+  @GetMapping("/childs")
+  public ResponseEntity<List<BoardResponse>> getChildBoards(
+          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    return ResponseEntity.ok(postService.getChildBoards());
+  }
+
+  // 게시글 삭제
+  @Operation(
+          summary = "게시판 삭제",
+          description = "게시판 ID를 통해 게시판을 삭제합니다."
+                  + "회장만 삭제할 수 있습니다."
+                  + "관련 첨부파일 및 댓글 등도 함께 삭제됩니다."
+  )
+  @DeleteMapping("/{boardId}")
+  public ResponseEntity<?> deleteBoard(
+          @PathVariable UUID boardId,
+          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    UUID userId = customUserDetails.getUserId();
+    postService.deleteBoard(boardId, userId);
+    return ResponseEntity.ok("게시판 삭제가 완료되었습니다.");
+  }
+
   // 좋아요 토글
   @Operation(
       summary = "좋아요 등록 및 취소",
@@ -236,4 +264,7 @@ public class BoardController {
     UUID userId = customUserDetails.getUserId();
     postInteractionService.deleteComment(commentId, userId);
   }
+
+
+
 }

--- a/backend/src/main/java/org/sejongisc/backend/board/repository/BoardRepository.java
+++ b/backend/src/main/java/org/sejongisc/backend/board/repository/BoardRepository.java
@@ -8,4 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface BoardRepository extends JpaRepository<Board, UUID> {
 
   List<Board> findAllByParentBoardIsNull();
+  List<Board> findAllByParentBoardIsNotNull();
+  List<Board> findAllByParentBoard_BoardId(UUID parentBoardId);
+
 }

--- a/backend/src/main/java/org/sejongisc/backend/board/repository/PostRepository.java
+++ b/backend/src/main/java/org/sejongisc/backend/board/repository/PostRepository.java
@@ -1,8 +1,10 @@
 package org.sejongisc.backend.board.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.sejongisc.backend.board.entity.Board;
 import org.sejongisc.backend.board.entity.Post;
+import org.sejongisc.backend.board.repository.projection.PostIdUserIdProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +25,11 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
       @Param("board") Board board,
       @Param("keyword") String keyword,
       Pageable pageable);
+
+  @Query("""
+           select p.postId as postId, p.user.userId as userId
+           from Post p
+           where p.board.boardId = :boardId
+           """)
+  List<PostIdUserIdProjection> findPostIdAndUserIdByBoardId(@Param("boardId") UUID boardId);
 }

--- a/backend/src/main/java/org/sejongisc/backend/board/repository/projection/PostIdUserIdProjection.java
+++ b/backend/src/main/java/org/sejongisc/backend/board/repository/projection/PostIdUserIdProjection.java
@@ -1,0 +1,8 @@
+package org.sejongisc.backend.board.repository.projection;
+
+import java.util.UUID;
+
+public interface PostIdUserIdProjection {
+    UUID getPostId();
+    UUID getUserId();
+}

--- a/backend/src/main/java/org/sejongisc/backend/board/service/PostService.java
+++ b/backend/src/main/java/org/sejongisc/backend/board/service/PostService.java
@@ -33,4 +33,7 @@ public interface PostService {
 
   // 부모 게시판 목록 조회
   List<BoardResponse> getParentBoards();
+  // 하위 게시판 목록 조회
+  List<BoardResponse> getChildBoards();
+  void deleteBoard(UUID boardId, UUID boardUserId);
 }

--- a/backend/src/main/java/org/sejongisc/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/org/sejongisc/backend/common/exception/ErrorCode.java
@@ -87,6 +87,8 @@ public enum ErrorCode {
 
   POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시물을 찾을 수 없습니다."),
 
+  INVALID_BOARD_OWNER(HttpStatus.FORBIDDEN, "게시판 수정/삭제 권한이 없습니다."),
+
   INVALID_POST_OWNER(HttpStatus.FORBIDDEN, "게시물 수정/삭제 권한이 없습니다."),
 
   COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
@@ -100,6 +102,9 @@ public enum ErrorCode {
   BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시판을 찾을 수 없습니다."),
 
   INVALID_BOARD_TYPE(HttpStatus.BAD_REQUEST, "상위 게시판에는 글을 작성할 수 없습니다.");
+
+
+
 
   private final HttpStatus status;
   private final String message;


### PR DESCRIPTION
1. 하위 게시판 목록 확인 API 생성
   - 엔드포인트 : GET /api/board/childs
   - 부모게시판ID가 존재하는 게시판 목록을 반환
2. 게시판 삭제 API 생성
   - 엔드포인트 : DELETE /api/board/{boradId}
   - 부모 게시판, 하위 게시판 상관없이 게시판과 연관된 게시물, 첨부파일등 정보와 함께 삭제
   - 부모 게시판의 경우 연관된 하위 게시판까지 삭제
   - UserRole : PRESIDENT만 게시판 삭제 가능
   - PostIdUserIdProjection 객체 생성하여 JPA에서 게시판과 연관된 게시물과 작성한 사용자의 ID를 받아옴

- 추가된 엔티티 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자식 게시판 조회 기능 추가
  * 게시판 삭제 기능 추가 (하위 게시판 및 관련 게시물 포함 삭제)
  * 게시판 소유자 권한 검증 기능 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->