### PR TITLE
[BE] [REFACTOR] PasswordPolicyValidator 비밀번호 특수문자 허용 범위 확장

### DIFF
--- a/backend/src/main/java/org/sejongisc/backend/user/util/PasswordPolicyValidator.java
+++ b/backend/src/main/java/org/sejongisc/backend/user/util/PasswordPolicyValidator.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class PasswordPolicyValidator {
 
     private static final Pattern PASSWORD_PATTERN =
-            Pattern.compile("^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=\\-{};:'\",.<>/?]).{8,20}$");
+      Pattern.compile("^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[^a-zA-Z0-9]).{8,20}$");
 
     public static String getValidatedPassword(String password) {
         String trimmed = sanitize(password);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 비밀번호 검증 정책이 업데이트되었습니다. 사용자는 이제 특정 기호에만 제한되지 않고 모든 특수 문자(기호)를 사용할 수 있습니다. 대문자, 소문자, 숫자 요구사항과 8-20자 길이 제한은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->