### PR TITLE
[FE] 출석조회 세션 선택 전 중복 발생 해결

### DIFF
--- a/frontend/src/components/attendance/SessionManage.jsx
+++ b/frontend/src/components/attendance/SessionManage.jsx
@@ -1,9 +1,7 @@
 import { useMemo } from 'react';
 import styles from './SessionManage.module.css';
 import { ClipboardCheck } from 'lucide-react';
-
-const normalizeSessionTitle = (sessionTitle) =>
-  typeof sessionTitle === 'string' && sessionTitle.trim() !== '' ? sessionTitle.trim() : '기타';
+import { normalizeSessionTitle } from '../../utils/normalizeSessionTitle';
 
 const getRoundKey = (session) => session.roundId || `${session.roundDate || ''}-${session.roundStartAt || ''}`;
 
@@ -84,9 +82,23 @@ const SessionManage = ({ sessions = [], selectedSession = '', loading, error }) 
       ? sessions.filter((session) => normalizeSessionTitle(session.sessionTitle) === selectedSessionTitle)
       : sessions;
 
-    const deduplicated = filtered.filter((session, index, array) => {
-      if (!session?.attendanceId) return true;
-      return array.findIndex((item) => item?.attendanceId === session.attendanceId) === index;
+    const seenAttendanceIds = new Set();
+    const deduplicated = [];
+
+    filtered.forEach((session) => {
+      const attendanceId = session?.attendanceId;
+
+      if (!attendanceId) {
+        deduplicated.push(session);
+        return;
+      }
+
+      if (seenAttendanceIds.has(attendanceId)) {
+        return;
+      }
+
+      seenAttendanceIds.add(attendanceId);
+      deduplicated.push(session);
     });
 
     return [...deduplicated].sort((a, b) => getTimestamp(a) - getTimestamp(b));

--- a/frontend/src/components/attendance/SessionSelectBox.jsx
+++ b/frontend/src/components/attendance/SessionSelectBox.jsx
@@ -1,8 +1,6 @@
 import styles from './SessionSelectBox.module.css';
 import { ClipboardCheck } from 'lucide-react';
-
-const normalizeSessionTitle = (sessionTitle) =>
-  typeof sessionTitle === 'string' ? sessionTitle.trim() : '';
+import { normalizeSessionTitle } from '../../utils/normalizeSessionTitle';
 
 const SessionSelectBox = ({
   sessions = [],
@@ -12,9 +10,7 @@ const SessionSelectBox = ({
 }) => {
   const sessionList = Array.from(
     new Set(
-      sessions
-        .map((session) => normalizeSessionTitle(session.sessionTitle))
-        .filter((sessionTitle) => sessionTitle !== ''),
+      sessions.map((session) => normalizeSessionTitle(session.sessionTitle)),
     ),
   );
 

--- a/frontend/src/pages/Attendance.jsx
+++ b/frontend/src/pages/Attendance.jsx
@@ -4,6 +4,7 @@ import SessionSelectBox from '../components/attendance/SessionSelectBox';
 // import ExcusedTime from '../components/attendance/ExcusedTime';
 import SessionManage from '../components/attendance/SessionManage';
 import { attendanceList } from '../utils/attendanceList';
+import { normalizeSessionTitle } from '../utils/normalizeSessionTitle';
 
 import { useAuthGuard } from '../hooks/useAuthGuard';
 import { useCheckIn } from '../hooks/useCheckIn';
@@ -21,8 +22,7 @@ const Attendance = () => {
     const uniqueSessionTitles = new Set();
 
     attendanceSessions.forEach((session) => {
-      const title = typeof session?.sessionTitle === 'string' ? session.sessionTitle.trim() : '';
-      if (title) uniqueSessionTitles.add(title);
+      uniqueSessionTitles.add(normalizeSessionTitle(session?.sessionTitle));
     });
 
     return Array.from(uniqueSessionTitles);

--- a/frontend/src/utils/attendanceList.js
+++ b/frontend/src/utils/attendanceList.js
@@ -1,10 +1,70 @@
 import { api } from './axios.js';
+import { getAttendanceSessions, getRounds } from './attendanceManage';
+
+const getSessionId = (session) =>
+  session?.sessionId || session?.attendanceSessionId || session?.id || null;
+
+const getSessionTitle = (session) =>
+  session?.session?.title || session?.title || session?.sessionTitle || '';
+
+const buildRoundMetaMap = async () => {
+  const sessions = await getAttendanceSessions();
+  if (!Array.isArray(sessions) || sessions.length === 0) return new Map();
+
+  const perSessionRoundMeta = await Promise.all(
+    sessions.map(async (session) => {
+      const sessionId = getSessionId(session);
+      if (!sessionId) return [];
+
+      try {
+        const rounds = await getRounds(sessionId);
+        if (!Array.isArray(rounds)) return [];
+
+        const sessionTitle = getSessionTitle(session);
+        return rounds
+          .filter((round) => !!round?.roundId)
+          .map((round) => [
+            round.roundId,
+            {
+              sessionTitle,
+              roundDate: round.roundDate,
+              roundStartAt: round.startAt || round.roundStartAt,
+            },
+          ]);
+      } catch {
+        return [];
+      }
+    }),
+  );
+
+  return new Map(perSessionRoundMeta.flat());
+};
 
 export const attendanceList = async () => {
   try {
     const res = await api.get('/api/attendance/me');
-    // console.log('API BASE URL:', import.meta.env.VITE_API_URL);
-    return res.data;
+
+    const records = Array.isArray(res.data) ? res.data : [];
+    if (records.length === 0) return records;
+
+    try {
+      const roundMetaMap = await buildRoundMetaMap();
+
+      return records.map((record) => {
+        const roundMeta = roundMetaMap.get(record?.roundId);
+        if (!roundMeta) return record;
+
+        return {
+          ...record,
+          sessionTitle: record?.sessionTitle || roundMeta.sessionTitle,
+          roundDate: record?.roundDate || roundMeta.roundDate,
+          roundStartAt: record?.roundStartAt || roundMeta.roundStartAt,
+        };
+      });
+    } catch {
+      // Keep attendance view available even if metadata enrichment fails.
+      return records;
+    }
   } catch (err) {
     console.error('출석 세션 불러오기 중 오류 발생: ', err);
     throw err;

--- a/frontend/src/utils/normalizeSessionTitle.js
+++ b/frontend/src/utils/normalizeSessionTitle.js
@@ -1,0 +1,10 @@
+const SESSION_TITLE_FALLBACK = '기타';
+
+export const normalizeSessionTitle = (sessionTitle) => {
+  if (typeof sessionTitle !== 'string') return SESSION_TITLE_FALLBACK;
+
+  const normalizedTitle = sessionTitle.trim();
+  return normalizedTitle !== '' ? normalizedTitle : SESSION_TITLE_FALLBACK;
+};
+
+export const getSessionTitleFallback = () => SESSION_TITLE_FALLBACK;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 세션 제목 정규화 및 기본값 도입으로 일관된 세션 표시 제공
  * 출석 데이터에 라운드 메타데이터(세션명, 라운드일시) 병합

* **버그 수정**
  * 세션 선택 드롭다운에서 빈 옵션 제거 및 선택값 동기화 개선
  * 중복 세션 항목 필터링 및 정렬 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->