### PR TITLE
[BE] SISC-298 [FEAT] 로컬 포트 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   db:
     image: postgres:16-alpine
     container_name: db
+    ports:
+      - "127.0.0.1:5432:5432"  # 외부 인터넷은 차단되고 서버 내부에서만 접속 가능
     environment:
       POSTGRES_DB: sisc_db
       POSTGRES_USER: ${DB_USERNAME}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * PostgreSQL 데이터베이스 보안 강화: 로컬 인트라넷 전용 포트 바인딩을 적용하여 외부 접근을 차단하고 내부 서비스만 데이터베이스에 연결 가능하도록 설정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->