### PR TITLE
[AI] [FIX] Kaggle 커널 순차 실행 가드 추가

### DIFF
--- a/AI/modules/signal/models/TCN/train_kaggle.py
+++ b/AI/modules/signal/models/TCN/train_kaggle.py
@@ -35,6 +35,16 @@ from torch.utils.data import DataLoader as TorchDataLoader
 from torch.utils.data import TensorDataset
 from tqdm import tqdm
 
+
+def log_gpu_status() -> None:
+    if torch.cuda.is_available():
+        devices = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
+        print(f"[INFO] GPU devices: {devices}")
+        print("[INFO] Using GPU")
+    else:
+        print("[INFO] GPU devices: []")
+        print("[INFO] Using CPU")
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 경로 설정
 # ─────────────────────────────────────────────────────────────────────────────
@@ -222,6 +232,7 @@ def train_model(args: argparse.Namespace):
 
     # 5. 모델
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log_gpu_status()
     print(f">> Device: {device}")
 
     model = TCNClassifier(

--- a/AI/modules/signal/models/itransformer/train_kaggle.py
+++ b/AI/modules/signal/models/itransformer/train_kaggle.py
@@ -35,6 +35,12 @@ from sklearn.preprocessing import StandardScaler
 
 from AI.modules.signal.models.itransformer.architecture import build_itransformer_model
 
+
+def log_gpu_status() -> None:
+    gpus = tf.config.list_physical_devices("GPU")
+    print(f"[INFO] GPU devices: {gpus}")
+    print("[INFO] Using GPU" if gpus else "[INFO] Using CPU")
+
 # Kaggle 경로 설정
 def _find_kaggle_dataset_path() -> str:
     """Kaggle 입력 데이터셋 경로 자동 탐색"""
@@ -265,6 +271,7 @@ def build_model(seq_len: int, n_features: int, n_outputs: int, n_tickers: int, n
 # 학습 메인
 # ─────────────────────────────────────────────────────────────────────────────
 def train():
+    log_gpu_status()
     print("=" * 56)
     print(" iTransformer Kaggle 학습 시작")
     print(f" Horizons: {CONFIG['horizons']}일")

--- a/AI/modules/signal/models/patchtst/train_kaggle.py
+++ b/AI/modules/signal/models/patchtst/train_kaggle.py
@@ -28,6 +28,16 @@ from torch.utils.data import DataLoader, TensorDataset
 from sklearn.preprocessing import MinMaxScaler
 from tqdm import tqdm
 
+
+def log_gpu_status() -> None:
+    if torch.cuda.is_available():
+        devices = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
+        print(f"[INFO] GPU devices: {devices}")
+        print("[INFO] Using GPU")
+    else:
+        print("[INFO] GPU devices: []")
+        print("[INFO] Using CPU")
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 경로 설정
 # Kaggle: /kaggle/input/sisc-ai-trading-dataset
@@ -204,6 +214,7 @@ def load_and_preprocess():
 # 학습 메인 (train.py와 동일)
 # ─────────────────────────────────────────────────────────────────────────────
 def train():
+    log_gpu_status()
     print("=" * 50)
     print(" PatchTST 학습 시작 (Kaggle 크론잡 버전)")
     print(f" 데이터: {CONFIG['parquet_dir']}")

--- a/AI/modules/signal/models/transformer/train_kaggle.py
+++ b/AI/modules/signal/models/transformer/train_kaggle.py
@@ -37,6 +37,8 @@ print("텐서플로우 버전:", tf.__version__)
 print("GPU 목록:", tf.config.list_physical_devices('GPU'))
 
 gpus = tf.config.list_physical_devices('GPU')
+print(f"[INFO] GPU devices: {gpus}")
+print("[INFO] Using GPU" if gpus else "[INFO] Using CPU")
 if gpus:
     try:
         for gpu in gpus:

--- a/AI/scripts/trigger_training.py
+++ b/AI/scripts/trigger_training.py
@@ -157,6 +157,32 @@ train()
     shutil.copytree(project_root / "AI", work_dir / "AI", ignore=ignore_ai_files)
 
 
+def get_kernel_status(spec: dict) -> str:
+    full_slug = f"{KAGGLE_USERNAME}/{spec['slug']}"
+    result = subprocess.run(
+        ["kaggle", "kernels", "status", full_slug],
+        capture_output=True,
+        text=True,
+    )
+    return (result.stdout or result.stderr or "").strip()
+
+
+def has_active_kernel() -> bool:
+    active_words = ("running", "queued", "pending")
+    for spec in MODEL_SPECS:
+        output = get_kernel_status(spec)
+        if any(word in output.lower() for word in active_words):
+            print(f"   [WAIT] Active Kaggle kernel: {KAGGLE_USERNAME}/{spec['slug']} -> {output}")
+            return True
+    return False
+
+
+def wait_until_no_active_kernel(poll_minutes: int) -> None:
+    while has_active_kernel():
+        print(f">> Active Kaggle kernel exists. Waiting {poll_minutes} minutes before next push.")
+        time.sleep(poll_minutes * 60)
+
+
 def trigger_kernel(spec: dict, dry_run: bool) -> bool:
     """로컬 메타데이터 기반 kaggle kernels push로 학습을 시작한다."""
     full_slug = f"{KAGGLE_USERNAME}/{spec['slug']}"
@@ -267,6 +293,9 @@ def main() -> int:
 
     failed = []
     for spec in models_to_run:
+        if not args.dry_run:
+            wait_until_no_active_kernel(args.poll_minutes)
+
         if not trigger_kernel(spec, dry_run=args.dry_run):
             failed.append(spec["name"])
             print(f"\n>> [{spec['name']}] 실패. 다음 모델로 넘어갑니다.")


### PR DESCRIPTION
## 개요
Kaggle 학습 커널이 동시에 push/실행되면서 GPU 할당이 불안정해지는 문제를 줄이기 위해 실행 중 커널 감지 및 대기 가드를 추가합니다.

## 변경사항
- `trigger_training.py`에서 기존 Kaggle 커널이 RUNNING/QUEUED/PENDING이면 다음 push 전에 대기
- 기본 실행(`--no-wait` 미사용) 시 모델별 push 후 완료까지 기다리는 기존 순차 흐름 유지
- PatchTST/Transformer/iTransformer/TCN Kaggle 학습 로그에 GPU/CPU 사용 여부 출력 추가

## 검증
- `python -m compileall -q AI/scripts/trigger_training.py AI/modules/signal/models/patchtst/train_kaggle.py AI/modules/signal/models/transformer/train_kaggle.py AI/modules/signal/models/itransformer/train_kaggle.py AI/modules/signal/models/TCN/train_kaggle.py`

## 운영 권장 명령
```bash
XAI_ENV_FILE=/home/hisiscadmin1/.env \
AI_MODEL_WEIGHTS_HOST_DIR=/mnt/storage/logs/ai-artifacts \
XAI_CONTAINER_NAME=quantbot-xai-training \
XAI_COMMAND="python AI/scripts/trigger_training.py --timeout-hours 12 --poll-minutes 5" \
/bin/bash /home/hisiscadmin1/bin/run_xai_cron.sh
```