### PR TITLE
[AI] [FIX] Kaggle P100 PyTorch CPU fallback

### DIFF
--- a/AI/modules/signal/models/TCN/train_kaggle.py
+++ b/AI/modules/signal/models/TCN/train_kaggle.py
@@ -36,14 +36,29 @@ from torch.utils.data import TensorDataset
 from tqdm import tqdm
 
 
-def log_gpu_status() -> None:
-    if torch.cuda.is_available():
-        devices = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
-        print(f"[INFO] GPU devices: {devices}")
-        print("[INFO] Using GPU")
-    else:
+def select_torch_device() -> torch.device:
+    if not torch.cuda.is_available():
         print("[INFO] GPU devices: []")
         print("[INFO] Using CPU")
+        return torch.device("cpu")
+
+    devices = []
+    usable_gpu = False
+    for idx in range(torch.cuda.device_count()):
+        name = torch.cuda.get_device_name(idx)
+        major, minor = torch.cuda.get_device_capability(idx)
+        devices.append(f"{name} sm_{major}{minor}")
+        if major >= 7:
+            usable_gpu = True
+
+    print(f"[INFO] GPU devices: {devices}")
+    if usable_gpu:
+        print("[INFO] Using GPU")
+        return torch.device("cuda")
+
+    print("[WARN] CUDA device is visible, but this PyTorch build requires sm_70+; falling back to CPU.")
+    print("[INFO] Using CPU")
+    return torch.device("cpu")
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 경로 설정
@@ -231,8 +246,7 @@ def train_model(args: argparse.Namespace):
     )
 
     # 5. 모델
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    log_gpu_status()
+    device = select_torch_device()
     print(f">> Device: {device}")
 
     model = TCNClassifier(

--- a/AI/modules/signal/models/patchtst/train_kaggle.py
+++ b/AI/modules/signal/models/patchtst/train_kaggle.py
@@ -29,14 +29,29 @@ from sklearn.preprocessing import MinMaxScaler
 from tqdm import tqdm
 
 
-def log_gpu_status() -> None:
-    if torch.cuda.is_available():
-        devices = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
-        print(f"[INFO] GPU devices: {devices}")
-        print("[INFO] Using GPU")
-    else:
+def select_torch_device() -> torch.device:
+    if not torch.cuda.is_available():
         print("[INFO] GPU devices: []")
         print("[INFO] Using CPU")
+        return torch.device("cpu")
+
+    devices = []
+    usable_gpu = False
+    for idx in range(torch.cuda.device_count()):
+        name = torch.cuda.get_device_name(idx)
+        major, minor = torch.cuda.get_device_capability(idx)
+        devices.append(f"{name} sm_{major}{minor}")
+        if major >= 7:
+            usable_gpu = True
+
+    print(f"[INFO] GPU devices: {devices}")
+    if usable_gpu:
+        print("[INFO] Using GPU")
+        return torch.device("cuda")
+
+    print("[WARN] CUDA device is visible, but this PyTorch build requires sm_70+; falling back to CPU.")
+    print("[INFO] Using CPU")
+    return torch.device("cpu")
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 경로 설정
@@ -256,7 +271,7 @@ def train():
     )
 
     # 5. 모델
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = select_torch_device()
     print(f">> Device: {device}\n")
 
     model = PatchTST_Model(


### PR DESCRIPTION
## 개요
Kaggle이 Tesla P100(sm_60)을 할당했을 때 현재 PyTorch CUDA 빌드가 sm_70 이상만 지원해 PatchTST/TCN 학습이 CUDA kernel image 오류로 실패하는 문제를 방지합니다.

## 변경사항
- PatchTST/TCN Kaggle 학습에서 CUDA availability만 보지 않고 device capability를 확인
- CUDA GPU가 보이더라도 sm_70 미만이면 CPU로 fallback
- fallback 시 로그에 GPU 목록과 CPU fallback 사유 출력

## 확인된 서버 로그 원인
- `Tesla P100-PCIE-16GB with CUDA capability sm_60 is not compatible with the current PyTorch installation`
- `torch.AcceleratorError: CUDA error: no kernel image is available for execution on the device`

## 검증
- `python -m compileall -q AI/modules/signal/models/patchtst/train_kaggle.py AI/modules/signal/models/TCN/train_kaggle.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * GPU 호환성 검증 로직을 강화하여 더 안정적인 기기 선택 기능 제공
  * 호환되지 않는 GPU 환경에서 자동으로 CPU로 폴백하도록 개선
  * 사용 불가능한 GPU 구성에 대한 경고 메시지 추가
  * AI 신호 처리 모델(TCN, PatchTST)의 학습 프로세스 최적화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SISC-IT/sisc-web/pull/367)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->